### PR TITLE
Fix score_by_section method - group it by section identifier

### DIFF
--- a/app/models/survey/attempt.rb
+++ b/app/models/survey/attempt.rb
@@ -111,9 +111,9 @@ class Survey::Attempt < ActiveRecord::Base
   def score_by_section
     answers_with_questions = self.answers.includes(question: :section)
     grouped_answers = answers_with_questions.group_by do |answer|
-      answer.question.section.name
+      answer.question.section.identifier
     end
-    
+
     grouped_answers.map do |category, answers|
       {
         identifier: category,

--- a/lib/survey/version.rb
+++ b/lib/survey/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Survey
-  VERSION = '1.7.13'
+  VERSION = '1.7.14'
 end

--- a/spec/models/survey/attempt_spec.rb
+++ b/spec/models/survey/attempt_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe Survey::Attempt, type: :model do
       it 'returns sum of answers score grouped by sections' do
         expect(subject.score_by_section).to eq([
           {
-            identifier: 'Section no. 5',
+            identifier: 'S1',
             score: 4
           },
           {
-            identifier: 'Section no. 6',
+            identifier: 'S2',
             score: 4
           },
         ])


### PR DESCRIPTION
Previously it was grouped by name, but the returned data structure suggested was grouped by the identifier.
```
{
  identifier: ...,
  score: ...
}
```